### PR TITLE
[🐸 Frogbot] Update version of com.google.code.gson:gson to 2.8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.1</version>
+            <version>2.8.9</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


## 📦 Vulnerable Dependencies

### ✍️ Summary
<div align='center'>

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                  | FIXED VERSIONS                  | CVES                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/notApplicableHigh.png)<br>    High | Not Applicable | com.google.code.gson:gson:2.8.1 | com.google.code.gson:gson 2.8.1 | [2.8.9] | CVE-2022-25647 |

</div>


### 🔬 Research Details


**Description:**
[Gson](https://github.com/google/gson) is a Java library that is used for simple serialization and deserialization of Java objects (to and from JSON format).
The Gson implementation has a design problem that leads to unsafe deserialization of untrusted data in the deserialization process of the following internal classes: `LinkedTreeMap`, `LinkedHashTreeMap`, and `LazilyParsedNumber`. Thus, a possible denial of service attack can be performed when trying to deserialize untrusted data to these types directly (serialized by Gson).

An attacker who controls the input data for the `ObjectInputStream.readObject()` call (or similar) can force the deserialization process to unsafely deserialize these internal classes directly. Forcing direct deserialization of these types can be achieved by manipulating the `ObjectStreamClass` descriptor of the input data (contains information about the serialized object). This is an unlikely and dangerous prerequisite, which would cause issues even unrelated to this vulnerability.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
